### PR TITLE
Update conversion value using NSInvocation

### DIFF
--- a/com.unity.ads.ios-support/Runtime/Plugins/iOS/SkAdNetworkManager.m
+++ b/com.unity.ads.ios-support/Runtime/Plugins/iOS/SkAdNetworkManager.m
@@ -32,23 +32,43 @@
 }
 
 - (void)updateConversionValue:(NSInteger)conversionValue {
-    if (!self.isAvailable)
+    if (!self.isAvailable) {
+        NSLog(@"updateConversionValue::Not properly initialized");
         return;
+    }
 
-    SEL requestSelector = NSSelectorFromString(@"updateConversionValue:");
-    if ([self.SkAdNetworkClass respondsToSelector:requestSelector]) {
-        NSNumber *val = [NSNumber numberWithInteger:conversionValue];
-        [self.SkAdNetworkClass performSelector:requestSelector withObject:val];
+    id target = self.SkAdNetworkClass;
+    SEL selector = NSSelectorFromString(@"updateConversionValue:");
+    NSMethodSignature * signature = [target methodSignatureForSelector:selector];
+    if (signature) {
+        NSLog(@"updateConversionValue::Invoking conversionValue=%ld", conversionValue);
+        NSInvocation * invocation = [NSInvocation invocationWithMethodSignature:signature];
+        invocation.target = target;
+        invocation.selector = selector;
+        [invocation setArgument:&conversionValue atIndex:2];
+        [invocation invoke];
+    } else {
+        NSLog(@"updateConversionValue::Unknown method signature");
     }
 }
 
 - (void)registerAppForAdNetworkAttribution {
-    if (!self.isAvailable)
+    if (!self.isAvailable) {
+        NSLog(@"registerAppForAdNetworkAttribution::Not properly initialized");
         return;
+    }
 
-    SEL requestSelector = NSSelectorFromString(@"registerAppForAdNetworkAttribution");
-    if ([self.SkAdNetworkClass respondsToSelector:requestSelector]) {
-        [self.SkAdNetworkClass performSelector:requestSelector];
+    id target = self.SkAdNetworkClass;
+    SEL selector = NSSelectorFromString(@"registerAppForAdNetworkAttribution");
+    NSMethodSignature * signature = [target methodSignatureForSelector:selector];
+    if (signature) {
+        NSLog(@"registerAppForAdNetworkAttribution::Invoking");
+        NSInvocation * invocation = [NSInvocation invocationWithMethodSignature:signature];
+        invocation.target = target;
+        invocation.selector = selector;
+        [invocation invoke];
+    } else {
+        NSLog(@"registerAppForAdNetworkAttribution::Unknown method signature");
     }
 }
 


### PR DESCRIPTION
We noticed that the current implementation of the [`updateConversionValue:` wrapper](https://developer.apple.com/documentation/storekit/skadnetwork/3566697-updateconversionvalue?language=objc) does not pass the value correctly to Apple's StoreKit framework.

According to its documentation, [`performSelector:withObject:`](https://developer.apple.com/documentation/objectivec/1418956-nsobject/1418764-performselector) should only be used to call a function with a single argument, which much be an object of type id. NSInteger is not a class, it is a type alias on top of an integral type. Hence, it cannot be used to call `(void)updateConversionValue:(NSInteger)conversionValue`. Documentation suggests to use `NSInvocation` instead, which is what this PR does.

This fix has been implemented as part of the GameGrowth package and has been tested in the wild. We now see conversion values being properly set in the SkAdNetwork postbacks we receive.