### PR TITLE
Making usage easier

### DIFF
--- a/com.unity.ads.ios-support/Runtime/iOSTransparency/ATTracking.cs
+++ b/com.unity.ads.ios-support/Runtime/iOSTransparency/ATTracking.cs
@@ -1,0 +1,57 @@
+﻿#if UNITY_IOS
+
+using System;
+using System.Collections.Generic;
+using UnityEngine.iOS;
+
+namespace Unity.Advertisement.IosSupport
+{
+    using TrackingStatus = ATTrackingStatusBinding.AuthorizationTrackingStatus;
+
+    public static class ATTracking
+    {
+        static Dictionary<int, TrackingStatus> Statuses = new Dictionary<int, TrackingStatus>()
+        {
+            { 0, TrackingStatus.NOT_DETERMINED},
+            { 1, TrackingStatus.RESTRICTED},
+            { 2, TrackingStatus.DENIED},
+            { 3, TrackingStatus.AUTHORIZED}
+        };
+        public static bool SupportediOSVersion => new Version(Device.systemVersion) > new Version("14.5");
+
+        public static bool IsTrackingAccepted()
+        {
+            // check with iOS to see if the user has accepted or declined tracking
+            var status = ATTrackingStatusBinding.GetAuthorizationTrackingStatus();
+
+            if (SupportediOSVersion)
+            {
+                return status == TrackingStatus.AUTHORIZED;
+            }
+            else
+            {
+                return true;
+            }
+        }
+
+        public static bool RequestAuthorizationTracking(Action<TrackingStatus> callback = null)
+        {
+            var authStatus = ATTrackingStatusBinding.GetAuthorizationTrackingStatus();
+
+            if (SupportediOSVersion)
+            {
+                if (authStatus == TrackingStatus.NOT_DETERMINED)
+                {
+                    ATTrackingStatusBinding.RequestAuthorizationTracking((requestStatus) =>
+                    {
+                        if (callback != null)
+                            callback.Invoke(Statuses[requestStatus]);
+                    });
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+}
+#endif

--- a/com.unity.ads.ios-support/Runtime/iOSTransparency/ATTracking.cs.meta
+++ b/com.unity.ads.ios-support/Runtime/iOSTransparency/ATTracking.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cedd5f7f66e90e44ba50a39fb03b9ffd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.ads.ios-support/Runtime/iOSTransparency/ATTracking.non_iOS.cs
+++ b/com.unity.ads.ios-support/Runtime/iOSTransparency/ATTracking.non_iOS.cs
@@ -11,7 +11,7 @@ namespace Unity.Advertisement.IosSupport
         public static bool SupportediOSVersion => false;
         public static bool IsTrackingAccepted()
         {
-            return false;
+            return true;
         }
         public static bool RequestAuthorizationTracking(Action<TrackingStatus> callback = null)
         {

--- a/com.unity.ads.ios-support/Runtime/iOSTransparency/ATTracking.non_iOS.cs
+++ b/com.unity.ads.ios-support/Runtime/iOSTransparency/ATTracking.non_iOS.cs
@@ -1,0 +1,23 @@
+﻿#if !UNITY_IOS
+
+using System;
+
+namespace Unity.Advertisement.IosSupport
+{
+    using TrackingStatus = ATTrackingStatusBinding.AuthorizationTrackingStatus;
+
+    public static class ATTracking
+    {
+        public static bool SupportediOSVersion => false;
+        public static bool IsTrackingAccepted()
+        {
+            return false;
+        }
+        public static bool RequestAuthorizationTracking(Action<TrackingStatus> callback = null)
+        {
+            // Do nothing
+            return false;
+        }
+    }
+}
+#endif

--- a/com.unity.ads.ios-support/Runtime/iOSTransparency/ATTracking.non_iOS.cs.meta
+++ b/com.unity.ads.ios-support/Runtime/iOSTransparency/ATTracking.non_iOS.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3be053b6204af6249aa4debaa5d9faeb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Added AATracking class in two variants:
1. iOS with implementations,
2. non-iOS for supporting compilation for all other platforms.

AATracking has easy to use Property called "bool SupportediOSVersion", it returns result of iOS version validation.
Also there is function "RequestAuthorizationTracking" with better callback implementation. Replaced raw int values to enum which tells more about the status in callback.