### PR TITLE
Add log when RequestTracking was not called

### DIFF
--- a/com.unity.ads.ios-support/Runtime/Plugins/iOS/TrackingAuthorizationManager.m
+++ b/com.unity.ads.ios-support/Runtime/Plugins/iOS/TrackingAuthorizationManager.m
@@ -38,6 +38,7 @@
 
 - (void)trackingAuthorizationRequest:(TrackingAuthorizationCompletion)completion {
     if (!self.isAvailable) {
+        NSLog(@"RequestTracking was not called. Because NSUserTrackingUsageDescription is not set or ATTrackingManager is not loaded.");
         if (completion != nil) {
             completion(0);
         }


### PR DESCRIPTION
If call RequestAuthorizationTracking without setting NSUserTrackingUsageDescription, the dialog will not appear.

At this time, no log output, so I thought it would be difficult to notice the mistake.

I added log output.